### PR TITLE
make the maximum message length configurable (default remains 2048)

### DIFF
--- a/src/main/dot-net/syslog4net/Layout/SyslogLayout.cs
+++ b/src/main/dot-net/syslog4net/Layout/SyslogLayout.cs
@@ -55,9 +55,10 @@ namespace syslog4net.Layout
                 var utf8 = Encoding.UTF8;
 
                 byte[] utfBytes = utf8.GetBytes(message);
-                if (utfBytes.Length > SyslogMaxMessageLength)
+                int lMaxMessageLength = Convert.ToInt32(this.MaxMessageLength);
+                if (utfBytes.Length > lMaxMessageLength)
                 {
-                    message = utf8.GetString(utfBytes, 0, SyslogMaxMessageLength);
+                    message = utf8.GetString(utfBytes, 0, lMaxMessageLength);
                 }
 
                 writer.Write(message);
@@ -68,6 +69,7 @@ namespace syslog4net.Layout
         /// Sets the syslog structured data ID. See http://tools.ietf.org/html/rfc5424#section-6.3.2 for more details.
         /// </summary>
         public string StructuredDataPrefix { get; set; }
+        public string MaxMessageLength { get; set; }
 
         /// <summary>
         /// Activates the use of options for the converter allowing the underlying PatternLayout implmentation to behave correctly
@@ -77,6 +79,14 @@ namespace syslog4net.Layout
             if (string.IsNullOrEmpty(this.StructuredDataPrefix))
             {
                 throw new ArgumentNullException("StructuredDataPrefix");
+            }
+            if (string.IsNullOrEmpty(this.MaxMessageLength))
+            {
+                this.MaxMessageLength = Convert.ToString(SyslogMaxMessageLength);
+            }
+            else 
+            {
+                this.MaxMessageLength = Convert.ToInt32(this.MaxMessageLength).ToString();
             }
             this._layout.ActivateOptions();
         }

--- a/src/test/unit/syslog4net.Tests/Layout/SyslogLayoutTests.cs
+++ b/src/test/unit/syslog4net.Tests/Layout/SyslogLayoutTests.cs
@@ -74,6 +74,31 @@ namespace syslog4net.Tests.Layout
             string result = writer.ToString();
 
             Assert.AreEqual(2048, result.Length);
-        }    
+        }
+        public void TestThatWeTruncateLongMessages5555()
+        {
+            SyslogLayout layout = new SyslogLayout();
+            layout.StructuredDataPrefix = "TEST@12345";
+            layout.MaxMessageLength = "5555";
+            layout.ActivateOptions();
+
+            StringBuilder longMessage = new StringBuilder();
+            for (int i = 0; i < 2048; i++)
+            {
+                longMessage.Append("test message");
+            }
+
+            var exception = new ArgumentNullException();
+            ILoggerRepository logRepository = Substitute.For<ILoggerRepository>();
+            var evt = new LoggingEvent(typeof(SyslogLayoutTests), logRepository, "test logger", Level.Debug, longMessage.ToString(), exception);
+
+            StringWriter writer = new StringWriter();
+
+            layout.Format(writer, evt);
+
+            string result = writer.ToString();
+
+            Assert.AreEqual(5555, result.Length);
+        }
     }
 }


### PR DESCRIPTION
Based on the notion that 2048 is only the recommended minimum supported length of syslog messages,
parties can agree on (or unilaterally accept) a different maximum length.
This patch allows the sending party to set a different maximum length, which could be less or more than the default 2048.