### PR TITLE
Update SyslogLayout.cs delmiter for time-secfrac portion of timestamp

### DIFF
--- a/src/main/dot-net/syslog4net/Layout/SyslogLayout.cs
+++ b/src/main/dot-net/syslog4net/Layout/SyslogLayout.cs
@@ -26,7 +26,7 @@ namespace syslog4net.Layout
         {
             IgnoresException = false;  //TODO deal with this. sealed?
 
-            this._layout = new PatternLayout("<%syslog-priority>1 %utcdate{yyyy-MM-ddTHH:mm:ss:FFZ} %syslog-hostname %appdomain"
+            this._layout = new PatternLayout("<%syslog-priority>1 %utcdate{yyyy-MM-ddTHH:mm:ss.FFZ} %syslog-hostname %appdomain"
                 + " %syslog-process-id %syslog-message-id %syslog-structured-data %message%newline");
 
             this._layout.AddConverter("syslog-priority", typeof(PriorityConverter));


### PR DESCRIPTION
To be compliant with RFC 3339 and ISO 8601, the time format must use a period "." delimiter for the time-secfrac portion of the timestamp.
Section "5.6. Internet Date/Time Format" of RFC 3339 defines the time-secfrac = "." 1*DIGIT

However currently syslog4net is using a colon ":" instead of a period ".".